### PR TITLE
Pick better dead zone for deselection click before ScreenShot

### DIFF
--- a/src/Screenshot/ScreenshotTrait.php
+++ b/src/Screenshot/ScreenshotTrait.php
@@ -116,8 +116,11 @@ trait ScreenshotTrait
     ) {
         // de-focus any selected elements
         $body = $this->findByTag('body');
+        $height = $body->getSize()->getHeight();
+        $x = 0;
+        $y = $height / 2;
         $action = new WebDriverActions($this->wd);
-        $action->moveToElement($body, 0, 0)->click()->perform();
+        $action->moveToElement($body, $x, $y)->click()->perform();
 
         $element = null;
 


### PR DESCRIPTION
Site logo is often in position 0 0 and clicking it goes to home page.

Instead click midway down viewport at x coordinate 0.