### PR TITLE
Work as symlink

### DIFF
--- a/bin/turing
+++ b/bin/turing
@@ -3,13 +3,15 @@
 
 namespace Silverorange\Turing;
 
+$dir = dirname($_SERVER['PHP_SELF']);
+
 $autoloadPaths = [
     // Try to load autoloader if this is the root project.
-    'root' => __DIR__ . '/../vendor/autoload.php',
+    'root' => $dir . '/../vendor/autoload.php',
 
     // Try to load an autoloader if this is installed as a library for
     // another root project.
-    'dependency' => __DIR__ . '/../../../autoload.php',
+    'dependency' => $dir . '/../autoload.php',
 ];
 
 foreach ($autoloadPaths as $type => $path) {
@@ -17,9 +19,9 @@ foreach ($autoloadPaths as $type => $path) {
         require_once $path;
 
         if ($type === 'dependency') {
-            define('STEWARD_BASE_DIR', realpath(__DIR__ . '/../../../..'));
+            define('STEWARD_BASE_DIR', realpath($dir . '/../../../..'));
         } else {
-            define('STEWARD_BASE_DIR', realpath(__DIR__ . '/..'));
+            define('STEWARD_BASE_DIR', realpath($dir . '/..'));
         }
 
         break;

--- a/bin/turing
+++ b/bin/turing
@@ -4,6 +4,7 @@
 namespace Silverorange\Turing;
 
 $dir = dirname($_SERVER['PHP_SELF']);
+$autoloaderInitialized = false;
 
 $autoloadPaths = [
     // Try to load autoloader if this is the root project.
@@ -24,8 +25,16 @@ foreach ($autoloadPaths as $type => $path) {
             define('STEWARD_BASE_DIR', realpath($dir . '/..'));
         }
 
+        $autoloaderInitialized = true;
         break;
     }
+}
+
+if (!$autoloaderInitialized) {
+  die(
+    'Unable to load project dependencies. Make sure you have run ' .
+    '"composer install".' . PHP_EOL . PHP_EOL
+  );
 }
 
 use Lmc\Steward\Console\EventListener\ListenerInstantiator;

--- a/src/Config/Environment.php
+++ b/src/Config/Environment.php
@@ -3,6 +3,7 @@
 namespace Silverorange\Turing\Config;
 
 use Dotenv\Dotenv;
+use Dotenv\Exception\InvalidPathException;
 
 /**
  * Valid environment variables for configuring Turing are:
@@ -37,7 +38,14 @@ abstract class Environment
         $testsPath = $rootPath . '/tests';
 
         $dotenv = new Dotenv($testsPath);
-        $dotenv->load();
+
+        try {
+            $dotenv->load();
+        } catch (InvalidPathException $e) {
+            // phpdotenv requires the .env file to exist but we want it to be
+            // optional. Catch InvalidPathException that is thrown when the
+            // file does not exist in the directory.
+        }
 
         $dotenv->required('SELENIUM_URL')->notEmpty();
         $dotenv->required('SELENIUM_SERVER_URL')->notEmpty();

--- a/src/Config/Environment.php
+++ b/src/Config/Environment.php
@@ -32,7 +32,8 @@ abstract class Environment
 {
     public static function load(): void
     {
-        $rootPath = dirname(dirname(dirname(dirname(dirname(__DIR__)))));
+        $dir = dirname($_SERVER['PHP_SELF']);
+        $rootPath = dirname(dirname($dir));
         $testsPath = $rootPath . '/tests';
 
         $dotenv = new Dotenv($testsPath);

--- a/src/Tests/AbstractTest.php
+++ b/src/Tests/AbstractTest.php
@@ -76,7 +76,8 @@ abstract class AbstractTest extends StewardAbstractTestCase
 
     protected function getProjectRoot()
     {
-        return dirname(dirname(dirname(dirname(dirname(__DIR__)))));
+        $dir = dirname($_SERVER['PHP_SELF']);
+        return dirname(dirname($dir));
     }
 
     // }}}


### PR DESCRIPTION
Makes the silverorange/turing package work when symlinked within a composer repository rather than installed.

Also makes the `.env` file optional.